### PR TITLE
Bumps rake version

### DIFF
--- a/datadog-queue-bus.gemspec
+++ b/datadog-queue-bus.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'queue-bus', '~> 0.6'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.72'
 end


### PR DESCRIPTION
There's a security vulnerability in lower versions of rake, this bumps
to avoid it.