### PR TITLE
Updates ddtrace dependency and switch to public tracing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0]
+- Updates ddtrace to the 1.X line and uses that version's `Datadog::Tracer` syntax
 
 ## [0.1.0]
 

--- a/datadog-queue-bus.gemspec
+++ b/datadog-queue-bus.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ddtrace', '~> 0.25'
+  spec.add_dependency 'ddtrace', '~> 1.0'
   spec.add_dependency 'queue-bus', '~> 0.6'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '~> 2.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.72'

--- a/lib/datadog_queue_bus/middleware.rb
+++ b/lib/datadog_queue_bus/middleware.rb
@@ -13,9 +13,10 @@ module DatadogQueueBus
       resource += " event=#{event_type}" if event_type
       resource += " sub=#{sub_key}" if sub_key
 
-      Datadog.tracer.trace('queue-bus.worker',
-                           service: DatadogQueueBus.service_name,
-                           resource: resource) do |span|
+      # def trace(name, continue_from: nil, **span_options, &block)
+      Datadog::Tracing.trace('queue-bus.worker',
+                             service: DatadogQueueBus.service_name,
+                             resource: resource) do |span|
         attrs.keys.grep(/^bus_/).each do |key|
           span.set_tag("queue-bus.#{key}", attrs[key])
         end

--- a/lib/datadog_queue_bus/version.rb
+++ b/lib/datadog_queue_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatadogQueueBus
-  VERSION = '0.1.0'
+  VERSION = '1.0.0'
 end

--- a/spec/datadog_queue_bus/middleware_spec.rb
+++ b/spec/datadog_queue_bus/middleware_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe DatadogQueueBus::Middleware do
       'bus_class_proxy' => 'QueueBus::Driver'
     }
   end
+  let(:tracer) { Datadog::Tracing }
 
   it 'uses the class_proxy_class as the resource name' do
-    expect(Datadog.tracer)
+    expect(tracer)
       .to receive(:trace)
       .with('queue-bus.worker', hash_including(resource: 'QueueBus::Driver'))
     subject.call(attrs)
@@ -27,7 +28,7 @@ RSpec.describe DatadogQueueBus::Middleware do
     end
 
     it 'sends the service name' do
-      expect(Datadog.tracer)
+      expect(tracer)
         .to receive(:trace)
         .with('queue-bus.worker', hash_including(service: name))
       subject.call(attrs)
@@ -40,7 +41,7 @@ RSpec.describe DatadogQueueBus::Middleware do
     end
 
     it 'includes the event in the resource' do
-      expect(Datadog.tracer)
+      expect(tracer)
         .to receive(:trace)
         .with('queue-bus.worker',
               hash_including(resource: a_string_matching(/event=my_event/)))
@@ -54,7 +55,7 @@ RSpec.describe DatadogQueueBus::Middleware do
     end
 
     it 'includes the sub key in the resource name' do
-      expect(Datadog.tracer)
+      expect(tracer)
         .to receive(:trace)
         .with('queue-bus.worker',
               hash_including(resource: a_string_matching(/sub=my_subscription/)))
@@ -69,7 +70,7 @@ RSpec.describe DatadogQueueBus::Middleware do
 
     it 'includes all attributes that start with bus_' do
       span = spy('span')
-      expect(Datadog.tracer).to receive(:trace).and_yield(span)
+      expect(tracer).to receive(:trace).and_yield(span)
       subject.call(attrs)
       expect(span).to have_received(:set_tag).with('queue-bus.bus_class_proxy', 'QueueBus::Driver')
       expect(span).to have_received(:set_tag).with('queue-bus.bus_field', 'my_field')
@@ -83,7 +84,7 @@ RSpec.describe DatadogQueueBus::Middleware do
 
     it 'includes all attributes that start with bus_' do
       span = spy('span')
-      expect(Datadog.tracer).to receive(:trace).and_yield(span)
+      expect(tracer).to receive(:trace).and_yield(span)
       subject.call(attrs)
       expect(span).to have_received(:set_tag).with('queue-bus.bus_class_proxy', 'QueueBus::Driver')
       expect(span).not_to have_received(:set_tag).with('queue-bus.user_id', 1234)


### PR DESCRIPTION
Datadog bumped their major version in Spring 2022 and this gem was never updated to compensate. Pin to 1.X releases going forward and update the Datadog.tracer call to instead uses the proper public tracing API.